### PR TITLE
Fix: Remove `console.log` statements

### DIFF
--- a/lib/createRenderer.js
+++ b/lib/createRenderer.js
@@ -43,8 +43,6 @@ const createRenderer = (
 
   linkProgram(gl)
   const uniforms = getActiveUniforms(gl, program);
-  
-  console.log(bindings)
 
   return {
     uniforms,

--- a/lib/createVertexArray.js
+++ b/lib/createVertexArray.js
@@ -50,8 +50,6 @@ const runBindings = (gl, program, attributes, indexOffset, hasTFBs = false) => {
       // const location = gl.getAttribLocation(program, names[i]);
       const location = isNaN(index)||index===null ? i+indexOffset : index;
 
-      console.log(data, buffer, attributes)
-  
       gl.bindAttribLocation(program, location, names[i]);
       gl.enableVertexAttribArray(location);
       gl.bindBuffer(gl.ARRAY_BUFFER, buffer);
@@ -84,9 +82,7 @@ const createVertexArray = (gl, program, attributes, indexOffset=0) => {
 
   const hasTFBs = Object.keys(tfbs).length > 0;
 
-  console.log(hasTFBs)
-
-  const bindings = runBindings(gl, program, attributes, indexOffset, hasTFBs)
+  const bindings = runBindings(gl, program, attributes, indexOffset, hasTFBs);
 
   return bindings;
   

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wtc-simplegl",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "A bare bones webgl library that provides the most basic setup possible with as little opinion as possible.",
   "main": "lib/index.js",
   "directories": {


### PR DESCRIPTION
These `console.log` statements were showing up in the compiled code.

The version is also bumped to `1.0.3`